### PR TITLE
UX: PDP related products, cart sizes, home cards; admin order design …

### DIFF
--- a/backend/src/controllers/adminOrders.controller.ts
+++ b/backend/src/controllers/adminOrders.controller.ts
@@ -171,10 +171,11 @@ export const getOrderByIdHandler = async (req: Request, res: Response) => {
                     include: {
                         product: {
                             include: {
-                                artist: { select: { id: true, name: true, displayName: true } }
-                            }
-                        }
-                    }
+                                artist: { select: { id: true, name: true, displayName: true } },
+                                design: { select: { id: true, designCode: true } },
+                            },
+                        },
+                    },
                 },
                 returnClaim: {
                     include: {
@@ -187,6 +188,53 @@ export const getOrderByIdHandler = async (req: Request, res: Response) => {
         if (!order) {
             return res.status(404).json({ status: "error", message: "Order not found" });
         }
+
+        const designIdSet = new Set<string>();
+        for (const item of order.items) {
+            const p = item.product;
+            if (!p) continue;
+            designIdSet.add(p.designId);
+            const st = p.draftEditorState as { frontDesign?: { id?: string }; backDesign?: { id?: string } } | null;
+            const fid = st?.frontDesign?.id;
+            const bid = st?.backDesign?.id;
+            if (typeof fid === "string" && fid) designIdSet.add(fid);
+            if (typeof bid === "string" && bid) designIdSet.add(bid);
+        }
+        const designRows =
+            designIdSet.size > 0
+                ? await prisma.design.findMany({
+                      where: { id: { in: [...designIdSet] } },
+                      select: { id: true, designCode: true },
+                  })
+                : [];
+        const designCodeById = new Map(
+            designRows.map((d) => [d.id, (d.designCode && String(d.designCode).trim()) || d.id.slice(0, 8).toUpperCase()])
+        );
+
+        type DesignCodeLabeled = { side: "front" | "back"; code: string };
+
+        const lineItemDesignCodesLabeled = (product: (typeof order.items)[0]["product"]): DesignCodeLabeled[] => {
+            if (!product) return [];
+            const st = product.draftEditorState as { frontDesign?: { id?: string }; backDesign?: { id?: string } } | null;
+            const frontId = typeof st?.frontDesign?.id === "string" ? st.frontDesign.id : undefined;
+            const backId = typeof st?.backDesign?.id === "string" ? st.backDesign.id : undefined;
+            const codeFor = (id: string | undefined): string | null => {
+                if (!id) return null;
+                return designCodeById.get(id) ?? null;
+            };
+            const out: DesignCodeLabeled[] = [];
+            const pushSide = (side: "front" | "back", id: string | undefined) => {
+                const c = codeFor(id);
+                if (c) out.push({ side, code: c });
+            };
+            if (frontId) pushSide("front", frontId);
+            if (backId && backId !== frontId) pushSide("back", backId);
+            if (out.length === 0) {
+                const c = codeFor(product.designId);
+                if (c) out.push({ side: "front", code: c });
+            }
+            return out;
+        };
 
         // Commission math: 25% of the item's unit price * quantity
         const COMMISSION_RATE = 0.25;
@@ -208,11 +256,14 @@ export const getOrderByIdHandler = async (req: Request, res: Response) => {
                 artistPayoutsMap.set(artistId, existing);
             }
 
+            const designCodesLabeled = lineItemDesignCodesLabeled(item.product);
             return {
                 id: item.id,
                 productId: item.productId,
                 productName: item.product?.name || "Unknown Product",
                 mockupImageUrl: item.product?.mockupImageUrl,
+                designCodes: designCodesLabeled.map((d) => d.code),
+                designCodesLabeled,
                 variant: `${item.size} / ${item.color}`,
                 quantity: item.quantity,
                 unitPrice: item.price,

--- a/backend/src/services/design.service.ts
+++ b/backend/src/services/design.service.ts
@@ -4,6 +4,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { nanoid } from "nanoid";
 import { r2 } from "../util/s3";
 import { PrismaClient } from "@prisma/client";
+import { collectDesignIdsFromManifestInput } from "./product.service";
 import sharp from "sharp";
 
 const prisma = new PrismaClient();
@@ -155,27 +156,35 @@ export const createDesignService = async (input: {
 
 export const getDesignsByArtistService = async (artistId: string) => {
     try {
-        const designs = await prisma.design.findMany({
-            where: {
-                artistId: artistId,
-                isDeleted: false,
-            },
-            include: {
-                products: {
-                    where: {
-                        status: { in: ["DRAFT", "PUBLISHED"] },
-                    },
-                    select: { id: true },
+        const [designs, activeProducts] = await Promise.all([
+            prisma.design.findMany({
+                where: {
+                    artistId: artistId,
+                    isDeleted: false,
                 },
-            },
-            orderBy: {
-                createdAt: "desc",
-            },
-        });
+                orderBy: {
+                    createdAt: "desc",
+                },
+            }),
+            prisma.product.findMany({
+                where: {
+                    artistId,
+                    status: { in: ["DRAFT", "PUBLISHED"] },
+                },
+                select: { designId: true, draftEditorState: true },
+            }),
+        ]);
 
-        return designs.map(d => ({
+        const usedDesignIds = new Set<string>();
+        for (const p of activeProducts) {
+            for (const id of collectDesignIdsFromManifestInput(p.designId, p.draftEditorState)) {
+                usedDesignIds.add(id);
+            }
+        }
+
+        return designs.map((d) => ({
             ...d,
-            isManifested: d.products.length > 0
+            isManifested: usedDesignIds.has(d.id),
         }));
     } catch (error: any) {
         console.error("[Designs] Database error:", error);

--- a/backend/src/services/product.service.ts
+++ b/backend/src/services/product.service.ts
@@ -7,6 +7,60 @@ const prisma = new PrismaClient();
 
 const PAID_ORDER_STATUSES = ["PAID", "SHIPPED", "DELIVERED"] as const;
 
+/** All design IDs “used” by a product row: FK + optional front/back from mockup editor JSON. */
+export function collectDesignIdsFromManifestInput(
+    designId: string,
+    draftEditorState: unknown
+): string[] {
+    const ids = new Set<string>();
+    if (designId) ids.add(designId);
+    let state: unknown = draftEditorState;
+    if (typeof state === "string") {
+        try {
+            state = JSON.parse(state) as unknown;
+        } catch {
+            state = null;
+        }
+    }
+    if (state && typeof state === "object" && !Array.isArray(state)) {
+        const front = (state as { frontDesign?: { id?: string } }).frontDesign?.id;
+        const back = (state as { backDesign?: { id?: string } }).backDesign?.id;
+        if (typeof front === "string" && front) ids.add(front);
+        if (typeof back === "string" && back) ids.add(back);
+    }
+    return [...ids];
+}
+
+/** No design ID may appear on more than one active (draft/published) product for the same artist. */
+async function assertDesignIdsExclusiveForArtist(
+    artistId: string,
+    designIds: string[],
+    excludeProductId?: string
+) {
+    const unique = [...new Set(designIds.filter(Boolean))];
+    if (unique.length === 0) return;
+
+    const siblings = await prisma.product.findMany({
+        where: {
+            artistId,
+            status: { in: ["DRAFT", "PUBLISHED"] },
+            ...(excludeProductId ? { id: { not: excludeProductId } } : {}),
+        },
+        select: { designId: true, draftEditorState: true },
+    });
+
+    for (const did of unique) {
+        for (const p of siblings) {
+            const used = new Set(collectDesignIdsFromManifestInput(p.designId, p.draftEditorState));
+            if (used.has(did)) {
+                throw new Error(
+                    "This design is already manifested in another active product. Each design belongs to a unique product identity."
+                );
+            }
+        }
+    }
+}
+
 /** Units assigned to new products when the artist does not send a stock value. Configured in admin (inventory_defaults). */
 export async function getDefaultProductStock(): Promise<number> {
     const row = await prisma.siteConfig.findUnique({ where: { key: "inventory_defaults" } });
@@ -172,18 +226,11 @@ export const createProductService = async (data: CreateProductInput) => {
         throw new Error("Only approved designs can be used to create products.");
     }
 
-    // --- NEW: Block Design Reuse ---
-    const existingProductNode = await prisma.product.findFirst({
-        where: {
-            designId: data.designId,
-            artistId: data.artistId,
-            status: { in: ["DRAFT", "PUBLISHED"] },
-        },
-    });
-    if (existingProductNode) {
-        throw new Error("This design is already manifested in another active product. Each design belongs to a unique product identity.");
-    }
-    // ---------------------------------
+    // Block design reuse on FK and on front/back slots in draftEditorState (back-only products use designId for back art).
+    await assertDesignIdsExclusiveForArtist(
+        data.artistId,
+        collectDesignIdsFromManifestInput(data.designId, data.draftEditorState)
+    );
 
     // Enforce 10-product limit per artist
     const productCount = await prisma.product.count({
@@ -517,6 +564,19 @@ export const updateProductService = async (
     if (product.status === "PUBLISHED") {
         throw new Error(
             "Published products cannot be edited. Create a new product if you need changes, or delete a draft first."
+        );
+    }
+
+    const touchesManifestDesigns =
+        data.designId !== undefined || data.draftEditorState !== undefined;
+    if (touchesManifestDesigns) {
+        const mergedDesignId = data.designId ?? product.designId;
+        const mergedDraft =
+            data.draftEditorState !== undefined ? data.draftEditorState : product.draftEditorState;
+        await assertDesignIdsExclusiveForArtist(
+            artistId,
+            collectDesignIdsFromManifestInput(mergedDesignId, mergedDraft),
+            id
         );
     }
 

--- a/frontend/src/components/modals/OrderDetailsModal.tsx
+++ b/frontend/src/components/modals/OrderDetailsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { X, Loader2, Package, User, MapPin, Truck, AlertCircle, Phone } from "lucide-react";
+import { Link } from "react-router-dom";
+import { X, Loader2, Package, User, MapPin, Truck, AlertCircle, Phone, ExternalLink } from "lucide-react";
 import api from "../../api/axios";
 import ReturnPolicyNote from "../shared/ReturnPolicyNote";
 
@@ -180,7 +181,41 @@ export default function OrderDetailsModal({ orderId, onClose }: OrderDetailsModa
                                                 <div className="flex flex-col sm:flex-row justify-between gap-2 items-start">
                                                     <div>
                                                         <h4 className="font-display text-[14px] font-black uppercase truncate">{item.productName}</h4>
+                                                        {item.productId && (
+                                                            <Link
+                                                                to={`/products/${item.productId}`}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                                className="mt-1 inline-flex items-center gap-1 font-display text-[10px] font-black uppercase text-primary underline underline-offset-2 decoration-2 decoration-primary hover:text-neutral-black hover:decoration-neutral-black"
+                                                            >
+                                                                <ExternalLink className="w-3 h-3 shrink-0" aria-hidden />
+                                                                Storefront product
+                                                            </Link>
+                                                        )}
                                                         <p className="font-display text-[11px] font-bold text-neutral-g4 uppercase mt-1">Var: {item.variant}</p>
+                                                        {Array.isArray(item.designCodesLabeled) && item.designCodesLabeled.length > 0 ? (
+                                                            <div className="mt-2 space-y-1">
+                                                                <p className="font-display text-[9px] font-black text-neutral-g3 uppercase tracking-wider">
+                                                                    Design codes
+                                                                </p>
+                                                                {item.designCodesLabeled.map(
+                                                                    (row: { side: string; code: string }, idx: number) => (
+                                                                        <p
+                                                                            key={`${row.side}-${row.code}-${idx}`}
+                                                                            className="font-display text-[10px] font-black text-neutral-black uppercase tracking-wide"
+                                                                        >
+                                                                            {row.side === "back" ? "Back" : "Front"}:{" "}
+                                                                            <span className="text-primary not-italic">{row.code}</span>
+                                                                        </p>
+                                                                    )
+                                                                )}
+                                                            </div>
+                                                        ) : Array.isArray(item.designCodes) && item.designCodes.length > 0 ? (
+                                                            <p className="font-display text-[10px] font-black text-neutral-black uppercase mt-2 tracking-wide">
+                                                                Design code{item.designCodes.length > 1 ? "s" : ""}:{" "}
+                                                                <span className="text-primary not-italic">{item.designCodes.join(" · ")}</span>
+                                                            </p>
+                                                        ) : null}
                                                     </div>
                                                     <div className="text-left sm:text-right">
                                                         <p className="font-display text-[14px] font-black italic">₹{item.totalPrice.toLocaleString('en-IN')}</p>

--- a/frontend/src/components/modals/SelectDesignModal.tsx
+++ b/frontend/src/components/modals/SelectDesignModal.tsx
@@ -47,7 +47,10 @@ const SelectDesignModal: React.FC<SelectDesignModalProps> = ({
     }, []);
 
     const handleSelect = (design: Design) => {
-        if (design.isManifested && design.id !== (targetView === "front" ? currentFrontDesignId : currentBackDesignId)) return;
+        const isCurrent = design.id === (targetView === "front" ? currentFrontDesignId : currentBackDesignId);
+        const isOther = targetView === "front" ? currentBackDesignId === design.id : currentFrontDesignId === design.id;
+        // Match grid `isManifestedDisabled`: allow same design on the other slot of this mockup session.
+        if (design.isManifested && !isCurrent && !isOther) return;
         if (design.status !== "APPROVED") return;
         onDesignSelect(design, targetView);
         onClose();

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -551,7 +551,7 @@ function HomePage() {
                                                 : specialOffer.discountPercent;
                                         return (
                                             <div key={product.id} className="w-full max-w-[320px] mx-auto group flex flex-col">
-                                                <div className="relative aspect-[4/5] bg-white rounded-[8px] border-[2.5px] border-neutral-black overflow-hidden transition-all duration-500 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] group-hover:bg-neutral-g1 group-hover:shadow-none group-hover:translate-x-[4px] group-hover:translate-y-[4px]">
+                                                <div className="relative aspect-[4/5] bg-white rounded-[8px] border-[2.5px] border-neutral-black overflow-hidden shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
                                                     <Link to={`/products/${product.id}`} className="no-underline w-full h-full block absolute inset-0 z-0">
                                                         {product.mockupImageUrl ? (
                                                             <ImageWithSkeleton
@@ -561,7 +561,7 @@ function HomePage() {
                                                                         : product.mockupImageUrl
                                                                 }
                                                                 alt={product.name}
-                                                                className={`absolute inset-0 h-full w-full ${STOREFRONT_TEE_MOCKUP_IMAGE_CLASS} transition-transform duration-500 group-hover:scale-[1.06]`}
+                                                                className={`absolute inset-0 h-full w-full scale-100 ${STOREFRONT_TEE_MOCKUP_IMAGE_CLASS} transition-transform duration-500 ease-out group-hover:scale-[1.06]`}
                                                                 wrapperClassName="h-full w-full overflow-hidden"
                                                             />
                                                         ) : (
@@ -588,26 +588,36 @@ function HomePage() {
                                                             <ShoppingCart className="w-5 h-5" />
                                                         </button>
                                                     </div>
-                                                    <div className="absolute bottom-0 left-0 w-full p-5 bg-gradient-to-t from-neutral-black to-transparent opacity-0 group-hover:opacity-100 transition-opacity z-10 pointer-events-none group-hover:pointer-events-auto">
-                                                        <div className="font-display text-[10px] font-black text-primary uppercase tracking-[2px] mb-1">
-                                                            {artistPublicDisplayName(product.artist)}
-                                                        </div>
-                                                        <div className="font-display text-[18px] font-black text-white leading-tight truncate">{product.name}</div>
-                                                    </div>
                                                 </div>
-                                                <div className="py-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                                                    <div className="flex items-baseline gap-3 flex-wrap">
-                                                        {strikePrice != null && (
-                                                            <span className="font-display text-[18px] font-black text-neutral-black/45 line-through tabular-nums">
-                                                                ₹{strikePrice.toLocaleString("en-IN")}
-                                                            </span>
-                                                        )}
-                                                        <span className="font-display text-[26px] font-black text-neutral-black tabular-nums">
-                                                            ₹{product.price.toLocaleString("en-IN")}
-                                                        </span>
+                                                <div className="py-5 flex flex-col gap-3">
+                                                    <div className="min-w-0 space-y-1">
+                                                        <Link
+                                                            to={artistPublicPath(product.artist)}
+                                                            className="font-display text-[10px] font-black text-neutral-black/55 uppercase tracking-[2px] truncate hover:text-neutral-black hover:underline decoration-2 underline-offset-2 no-underline block"
+                                                        >
+                                                            {artistPublicDisplayName(product.artist)}
+                                                        </Link>
+                                                        <Link
+                                                            to={`/products/${product.id}`}
+                                                            className="font-display text-[15px] sm:text-[16px] font-black text-neutral-black uppercase leading-snug tracking-tight truncate no-underline block hover:underline decoration-2 underline-offset-2 decoration-neutral-black"
+                                                        >
+                                                            {product.name}
+                                                        </Link>
                                                     </div>
-                                                    <div className="font-display text-[10px] font-black text-neutral-black/50 uppercase tracking-[2px]">
-                                                        {(product.categories?.[0] || product.category || "Design").toString()}
+                                                    <div className="flex flex-wrap items-end justify-between gap-3">
+                                                        <div className="flex items-baseline gap-3 flex-wrap">
+                                                            {strikePrice != null && (
+                                                                <span className="font-display text-[18px] font-black text-neutral-black/45 line-through tabular-nums">
+                                                                    ₹{strikePrice.toLocaleString("en-IN")}
+                                                                </span>
+                                                            )}
+                                                            <span className="font-display text-[26px] font-black text-neutral-black tabular-nums">
+                                                                ₹{product.price.toLocaleString("en-IN")}
+                                                            </span>
+                                                        </div>
+                                                        <div className="font-display text-[10px] font-black text-neutral-black/50 uppercase tracking-[2px] shrink-0">
+                                                            {(product.categories?.[0] || product.category || "Design").toString()}
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>
@@ -716,7 +726,7 @@ function HomePage() {
                                     key={product.id}
                                     className="w-[280px] max-w-[92vw] md:w-[320px] shrink-0 snap-start group"
                                 >
-                                    <div className="relative isolate aspect-[4/5] bg-neutral-black rounded-[8px] border-[2.5px] border-neutral-black overflow-hidden transition-all duration-500 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-[4px] hover:translate-y-[4px]">
+                                    <div className="relative isolate aspect-[4/5] bg-neutral-black rounded-[8px] border-[2.5px] border-neutral-black overflow-hidden shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
                                         <Link to={`/products/${product.id}`} className="absolute inset-0 z-0 no-underline">
                                             {product.mockupImageUrl ? (
                                                 <ImageWithSkeleton
@@ -726,7 +736,7 @@ function HomePage() {
                                                             : product.mockupImageUrl
                                                     }
                                                     alt={product.name}
-                                                    className={`absolute inset-0 h-full w-full min-h-[101%] min-w-full max-w-none ${STOREFRONT_TEE_MOCKUP_IMAGE_CLASS} transition-transform duration-500 will-change-transform backface-hidden group-hover:scale-[1.06]`}
+                                                    className={`absolute inset-0 h-full w-full min-h-[101%] min-w-full max-w-none scale-100 ${STOREFRONT_TEE_MOCKUP_IMAGE_CLASS} transition-transform duration-500 ease-out will-change-transform backface-hidden group-hover:scale-[1.06]`}
                                                     wrapperClassName="absolute inset-0 min-h-0 overflow-hidden bg-neutral-black"
                                                     wrapperLayout="absolute-fill"
                                                 />
@@ -742,44 +752,54 @@ function HomePage() {
                                             </div>
                                         )}
 
-                                        <div className="absolute top-4 right-4 flex flex-col gap-2 scale-0 group-hover:scale-100 transition-all duration-300">
+                                        <div className="absolute top-4 right-4 z-20 flex flex-col gap-2 scale-0 group-hover:scale-100 transition-all duration-300">
                                             <button
+                                                type="button"
                                                 onClick={() => handleQuickAdd(product)}
                                                 className={`w-12 h-12 rounded-[4px] border-[2px] border-neutral-black flex items-center justify-center transition-all shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-y-1 ${addedId === product.id ? 'bg-success text-white' : 'bg-white text-neutral-black hover:bg-neutral-black hover:text-white'}`}
                                             >
                                                 <ShoppingCart className="w-5 h-5" />
                                             </button>
                                         </div>
-
-                                        <div className="absolute bottom-0 left-0 w-full p-6 bg-gradient-to-t from-neutral-black to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
-                                            <div className="font-display text-[10px] font-black text-primary uppercase tracking-[2px] mb-1">
-                                                {artistPublicDisplayName(product.artist)}
-                                            </div>
-                                            <div className="font-display text-[20px] font-black text-white hover:text-primary transition-colors cursor-pointer truncate">{product.name}</div>
-                                        </div>
                                     </div>
-                                    <div className="py-5 flex items-center justify-between gap-2 flex-wrap">
-                                        <div className="flex items-baseline gap-2 flex-wrap min-w-0">
-                                            {product.isDiscounted &&
-                                                product.originalPrice != null &&
-                                                product.originalPrice > product.price && (
-                                                    <span className="font-display text-[16px] font-black text-white/45 line-through tabular-nums">
-                                                        ₹{product.originalPrice.toLocaleString("en-IN")}
-                                                    </span>
-                                                )}
-                                            {!product.isDiscounted &&
-                                                product.compareAtPrice != null &&
-                                                product.compareAtPrice > product.price && (
-                                                    <span className="font-display text-[16px] font-black text-white/45 line-through tabular-nums">
-                                                        ₹{product.compareAtPrice.toLocaleString("en-IN")}
-                                                    </span>
-                                                )}
-                                            <div className="font-display text-[24px] font-black text-white italic tracking-tighter tabular-nums">
-                                                ₹{product.price.toLocaleString("en-IN")}
-                                            </div>
+                                    <div className="py-5 flex flex-col gap-3">
+                                        <div className="min-w-0 space-y-1">
+                                            <Link
+                                                to={artistPublicPath(product.artist)}
+                                                className="font-display text-[10px] font-black text-primary uppercase tracking-[2px] truncate hover:text-white hover:underline decoration-2 underline-offset-2 no-underline block"
+                                            >
+                                                {artistPublicDisplayName(product.artist)}
+                                            </Link>
+                                            <Link
+                                                to={`/products/${product.id}`}
+                                                className="font-display text-[16px] md:text-[18px] font-black text-white uppercase leading-snug tracking-tight truncate no-underline block hover:underline decoration-2 underline-offset-2 decoration-primary"
+                                            >
+                                                {product.name}
+                                            </Link>
                                         </div>
-                                        <div className="font-display text-[10px] font-black text-white/40 uppercase tracking-[2px] shrink-0">
-                                            {(product.categories?.[0] || product.category || "Design").toString()}
+                                        <div className="flex items-center justify-between gap-2 flex-wrap">
+                                            <div className="flex items-baseline gap-2 flex-wrap min-w-0">
+                                                {product.isDiscounted &&
+                                                    product.originalPrice != null &&
+                                                    product.originalPrice > product.price && (
+                                                        <span className="font-display text-[16px] font-black text-white/45 line-through tabular-nums">
+                                                            ₹{product.originalPrice.toLocaleString("en-IN")}
+                                                        </span>
+                                                    )}
+                                                {!product.isDiscounted &&
+                                                    product.compareAtPrice != null &&
+                                                    product.compareAtPrice > product.price && (
+                                                        <span className="font-display text-[16px] font-black text-white/45 line-through tabular-nums">
+                                                            ₹{product.compareAtPrice.toLocaleString("en-IN")}
+                                                        </span>
+                                                    )}
+                                                <div className="font-display text-[24px] font-black text-white italic tracking-tighter tabular-nums">
+                                                    ₹{product.price.toLocaleString("en-IN")}
+                                                </div>
+                                            </div>
+                                            <div className="font-display text-[10px] font-black text-white/40 uppercase tracking-[2px] shrink-0">
+                                                {(product.categories?.[0] || product.category || "Design").toString()}
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -816,13 +836,13 @@ function HomePage() {
                             </p>
                             <div className="flex flex-wrap gap-5">
                                 <Link to="/artists" className="group/btn relative px-10 py-5 bg-primary text-neutral-black font-display text-[16px] font-black uppercase tracking-[2px] rounded-[4px] transition-all duration-300 shadow-[8px_8px_0px_0px_rgba(255,222,0,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(255,222,0,1)] hover:translate-x-[4px] hover:translate-y-[4px] no-underline inline-flex items-center gap-4">
-                                    Browse Directory <ArrowRight className="w-5 h-5 group-hover/btn:translate-x-2 transition-transform" />
+                                    Browse Artists <ArrowRight className="w-5 h-5 group-hover/btn:translate-x-2 transition-transform" />
                                 </Link>
                                 <button
                                     onClick={handleRegisterNode}
                                     className="px-10 py-5 bg-transparent text-white border-[2.5px] border-white/20 hover:border-primary hover:text-primary font-display text-[16px] font-black uppercase tracking-[2px] rounded-[4px] transition-all"
                                 >
-                                    Register Node
+                                    Become an Artist
                                 </button>
                             </div>
                         </div>
@@ -875,7 +895,7 @@ function HomePage() {
                     { icon: Shirt, title: "Comfy Tees", sub: "Quality cotton prints made to feel good and last." },
                     { icon: Palette, title: "25% Royalty", sub: "A meaningful slice of every sale goes to the creator." },
                     { icon: ShieldCheck, title: "5-day returns", sub: "Not the right fit? You have five days to start a return." },
-                    { icon: Truck, title: "Free Shipping", sub: "We ship across India at no extra delivery charge." },
+                    { icon: Truck, title: "Free Shipping", sub: "We ship across India at no extra delivery charge. Most orders arrive in 5–7 business days." },
                 ].map((item, i) => (
                     <div key={i} className={`p-10 flex flex-col items-center text-center gap-6 group hover:bg-neutral-black/50 transition-all ${i < 3 ? 'lg:border-r-[2px] border-white/10' : ''}`}>
                         <div className="w-16 h-16 bg-primary text-neutral-black rounded-[4px] flex items-center justify-center shadow-[4px_4px_0px_0px_rgba(255,255,255,0.1)] group-hover:shadow-[4px_4px_0px_0px_rgba(255,222,0,0.5)] group-hover:translate-x-[-2px] group-hover:translate-y-[-2px] transition-all rotate-[5deg] group-hover:rotate-0">

--- a/frontend/src/pages/customer/CartPage.tsx
+++ b/frontend/src/pages/customer/CartPage.tsx
@@ -222,7 +222,7 @@ export default function Cart() {
                                                         <div className="flex flex-col gap-4 mt-6">
                                                             <div className="flex flex-col gap-2 font-display text-[11px] font-bold text-neutral-black/45 tracking-[0.3px]">
                                                                 <span>Size</span>
-                                                                <div className="flex flex-wrap gap-2">
+                                                                <div className="flex flex-wrap ml-1 gap-2">
                                                                     {PRODUCT_SIZES.map((size) => (
                                                                         <button
                                                                             key={size}
@@ -236,10 +236,10 @@ export default function Cart() {
                                                                                     item.color
                                                                                 )
                                                                             }
-                                                                            className={`min-w-[40px] px-2 py-1.5 rounded-[2px] border-[1.5px] font-display text-[11px] font-black transition-all ${
+                                                                            className={`min-w-[46px] h-[44px] px-1.5 sm:min-w-[52px] sm:h-[48px] rounded-[2px] border-[1.5px] font-display text-[11px] sm:text-[12px] font-black transition-all ${
                                                                                 item.size === size
-                                                                                    ? "border-neutral-black bg-primary text-neutral-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]"
-                                                                                    : "border-neutral-g2 bg-white text-neutral-g3 hover:border-neutral-black hover:text-neutral-black"
+                                                                                    ? "border-neutral-black bg-primary text-neutral-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] -translate-x-0.5 -translate-y-0.5"
+                                                                                    : "border-neutral-black bg-white text-neutral-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"
                                                                             }`}
                                                                         >
                                                                             {size}

--- a/frontend/src/pages/customer/ProductDetails.tsx
+++ b/frontend/src/pages/customer/ProductDetails.tsx
@@ -21,7 +21,11 @@ import GstInclusiveNote from "../../components/shared/GstInclusiveNote";
 import ReturnPolicyNote from "../../components/shared/ReturnPolicyNote";
 import { BEE_BADGE } from "../../constants/brand";
 import { artistPublicPath, artistPublicDisplayName } from "../../utils/artistRoutes";
-import { STOREFRONT_TEE_MOCKUP_IMAGE_CLASS } from "../../utils/productMockup";
+import {
+    STOREFRONT_TEE_MOCKUP_IMAGE_CLASS,
+    frontMockupUrl,
+    backMockupUrl,
+} from "../../utils/productMockup";
 import ArtistRatingInline from "../../components/shared/ArtistRatingInline";
 
 interface Product {
@@ -65,6 +69,33 @@ interface Product {
     }>;
 }
 
+/** Listing shape from `/api/products` for related picks + shop-style cards */
+interface RelatedListingProduct {
+    id: string;
+    name: string;
+    price: number;
+    originalPrice?: number;
+    isDiscounted?: boolean;
+    discountPercent?: number;
+    compareAtPrice?: number;
+    categories?: string[];
+    tshirtColor: string;
+    primaryColor?: string;
+    availableColors?: string[];
+    colorMockups?: Record<string, { front: string; back?: string }> | null;
+    mockupImageUrl: string;
+    backMockupImageUrl?: string;
+    primaryView?: "front" | "back";
+    artist: {
+        id: string;
+        name: string;
+        displayName?: string | null;
+        artistSlug?: string | null;
+        artistRating: number;
+        reviewCount: number;
+    };
+}
+
 export default function ProductDetails() {
     const { productId } = useParams<{ productId: string }>();
     const navigate = useNavigate();
@@ -77,6 +108,9 @@ export default function ProductDetails() {
     const [quantity, setQuantity] = useState(1);
     const [addedToCart, setAddedToCart] = useState(false);
     const [sizeGuideOpen, setSizeGuideOpen] = useState(false);
+    const [relatedProducts, setRelatedProducts] = useState<RelatedListingProduct[]>([]);
+    const [relatedLoading, setRelatedLoading] = useState(false);
+    const [relatedAddedId, setRelatedAddedId] = useState<string | null>(null);
     const { addItem, items } = useCart();
 
     const sizes = PRODUCT_SIZES;
@@ -220,6 +254,79 @@ export default function ProductDetails() {
 
         if (productId) fetchProduct();
     }, [productId]);
+
+    useEffect(() => {
+        if (!product) {
+            setRelatedProducts([]);
+            return;
+        }
+        const loadRelated = async () => {
+            setRelatedLoading(true);
+            try {
+                const res = await api.get("/api/products?limit=48&sort=popular");
+                const list: RelatedListingProduct[] = res.data?.data?.products ?? [];
+                const curCats = new Set(
+                    (product.categories || []).map((c) => String(c).toLowerCase().trim()).filter(Boolean)
+                );
+                const scored = list
+                    .filter((p) => p.id !== product.id)
+                    .map((p) => {
+                        let score = 0;
+                        if (p.artist?.id === product.artist.id) score += 4;
+                        for (const c of p.categories || []) {
+                            if (curCats.has(String(c).toLowerCase().trim())) {
+                                score += 2;
+                                break;
+                            }
+                        }
+                        return { p, score };
+                    })
+                    .sort((a, b) => b.score - a.score)
+                    .map(({ p }) => p)
+                    .slice(0, 8);
+                setRelatedProducts(scored);
+            } catch {
+                setRelatedProducts([]);
+            } finally {
+                setRelatedLoading(false);
+            }
+        };
+        loadRelated();
+    }, [product]);
+
+    const handleRelatedQuickAdd = (p: RelatedListingProduct) => {
+        const colors = p.availableColors?.length ? p.availableColors : [p.tshirtColor];
+        const pickColor = p.primaryColor || p.tshirtColor;
+        const baseMock = {
+            mockupImageUrl: p.mockupImageUrl,
+            backMockupImageUrl: p.backMockupImageUrl,
+            colorMockups: p.colorMockups,
+            primaryColor: p.primaryColor,
+            tshirtColor: p.tshirtColor,
+        };
+        const useBack = p.primaryView === "back";
+        const img = useBack ? backMockupUrl(baseMock, pickColor) : frontMockupUrl(baseMock, pickColor);
+        addItem({
+            productId: p.id,
+            name: p.name,
+            price: p.price,
+            quantity: 1,
+            size: "M",
+            color: canonicalHex(pickColor),
+            image: img,
+            mockupImageUrl: p.mockupImageUrl,
+            backMockupImageUrl: p.backMockupImageUrl,
+            defaultProductColor: p.tshirtColor,
+            primaryColor: p.primaryColor,
+            primaryView: p.primaryView,
+            mockupView: useBack ? "back" : "front",
+            colorMockups: p.colorMockups ?? undefined,
+            artistName: artistPublicDisplayName(p.artist),
+            availableColors: colors,
+        });
+        setRelatedAddedId(p.id);
+        setTimeout(() => setRelatedAddedId(null), 2000);
+    };
 
     if (isLoading) {
         return (
@@ -365,7 +472,7 @@ export default function ProductDetails() {
                     </div>
 
                     {/* RIGHT: Product Info — tighter vertical rhythm for first-screen fit */}
-                    <div className="space-y-5 sm:space-y-5 lg:space-y-4 lg:max-h-[min(78vh,680px)] lg:overflow-y-auto lg:pr-2 [scrollbar-width:thin] pb-2">
+                    <div className="space-y-5 sm:space-y-5 lg:space-y-4 pb-2">
                         <div>
                             <div className="flex flex-wrap items-center gap-2 mb-2">
                                 <StockStatusPill stockStatus={currentStockStatus} />
@@ -465,7 +572,7 @@ export default function ProductDetails() {
                                         Size Guide
                                     </button>
                                 </div>
-                                <div className="flex flex-wrap gap-2">
+                                <div className="flex flex-wrap ml-1 gap-2">
                                     {sizes.map((size) => {
                                         const soldOut = isGloballyUnavailable(selectedColor, size) || (hasVariantInventory && isVariantUnavailable(selectedColor, size));
                                         return (
@@ -476,7 +583,9 @@ export default function ProductDetails() {
                                                 onClick={() => setSelectedSize(size)}
                                                 className={`min-w-[46px] h-[44px] px-1.5 sm:min-w-[52px] sm:h-[48px] rounded-[2px] border-[1.5px] font-display text-[11px] sm:text-[12px] font-black transition-all ${selectedSize === size
                                                     ? "border-neutral-black bg-primary text-neutral-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] -translate-x-0.5 -translate-y-0.5"
-                                                    : soldOut ? "border-neutral-g1 bg-neutral-g1 text-neutral-g2 opacity-50 cursor-not-allowed line-through" : "border-neutral-g2 text-neutral-g3 hover:border-neutral-black hover:text-neutral-black"
+                                                    : soldOut
+                                                        ? "border-neutral-g1 bg-neutral-g1 text-neutral-g2 opacity-50 cursor-not-allowed line-through shadow-none"
+                                                        : "border-neutral-black bg-white text-neutral-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"
                                                     }`}
                                             >
                                                 {size}
@@ -565,7 +674,7 @@ export default function ProductDetails() {
                                 <div className="w-8 h-8 sm:w-9 sm:h-9 bg-neutral-g1 border border-neutral-g2 rounded-full flex items-center justify-center shrink-0">
                                     <Truck className="w-3.5 h-3.5 text-primary" />
                                 </div>
-                                <span className="leading-tight">Free<br />Shipping</span>
+                                <span className="leading-tight">5-7 Days<br />Delivery</span>
                             </div>
                             <div className="flex items-center gap-2 text-neutral-g4 font-display text-[9px] sm:text-[10px] font-extrabold uppercase tracking-[0.04em]">
                                 <div className="w-8 h-8 sm:w-9 sm:h-9 bg-neutral-g1 border border-neutral-g2 rounded-full flex items-center justify-center shrink-0">
@@ -583,6 +692,106 @@ export default function ProductDetails() {
                         <ReturnPolicyNote className="mt-3" />
                     </div>
                 </div>
+
+                {/* Related — same category / same artist first, shop-style cards */}
+                {(relatedLoading || relatedProducts.length > 0) && (
+                    <section className="mt-14 sm:mt-20 pt-10 sm:pt-12 border-t-[1.5px] border-neutral-g2">
+                        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-8">
+                            <div>
+                                <p className="font-display text-[10px] font-extrabold tracking-[2px] uppercase text-neutral-g3 mb-2">
+                                    <span aria-hidden>{BEE_BADGE}</span> More from the hive
+                                </p>
+                                <h2 className="font-display text-[clamp(22px,3vw,32px)] font-black text-neutral-black uppercase tracking-tight">
+                                    You may also like
+                                </h2>
+                            </div>
+                            <Link
+                                to="/products"
+                                className="font-display text-[11px] font-black uppercase tracking-wide text-neutral-black underline underline-offset-2 decoration-2 hover:text-primary transition-colors shrink-0"
+                            >
+                                View all products
+                            </Link>
+                        </div>
+                        {relatedLoading ? (
+                            <div className="flex justify-center py-16">
+                                <Loader size="w-12 h-12" />
+                            </div>
+                        ) : (
+                            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
+                                {relatedProducts.map((rp) => (
+                                    <div
+                                        key={rp.id}
+                                        className="bg-white border-[1.5px] border-neutral-g2 rounded-[4px] overflow-hidden group/card transition-all hover:shadow-[0_12px_40px_rgba(0,0,0,0.08)] hover:border-neutral-black"
+                                    >
+                                        <Link to={`/products/${rp.id}`} className="block aspect-square overflow-hidden bg-neutral-g1 relative">
+                                            <ImageWithSkeleton
+                                                src={
+                                                    rp.primaryView === "back"
+                                                        ? rp.backMockupImageUrl || rp.mockupImageUrl
+                                                        : rp.mockupImageUrl
+                                                }
+                                                alt={rp.name}
+                                                className={`w-full h-full ${STOREFRONT_TEE_MOCKUP_IMAGE_CLASS} group-hover/card:scale-105 transition-transform`}
+                                                wrapperClassName="w-full h-full"
+                                            />
+                                            {rp.isDiscounted && (rp.discountPercent ?? 0) > 0 && (
+                                                <div className="absolute top-2 left-2 sm:top-3 sm:left-3 bg-danger text-white font-display text-[9px] sm:text-[10px] font-black px-1.5 py-0.5 sm:px-2 sm:py-1 uppercase tracking-[1px] shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] z-10">
+                                                    -{rp.discountPercent}%
+                                                </div>
+                                            )}
+                                        </Link>
+                                        <div className="p-3 sm:p-4">
+                                            <Link
+                                                to={artistPublicPath(rp.artist)}
+                                                className="font-display text-[9px] sm:text-[10px] font-bold tracking-[1.5px] uppercase text-neutral-g4 mb-1 block hover:text-neutral-black transition-colors no-underline truncate"
+                                            >
+                                                {artistPublicDisplayName(rp.artist)}
+                                            </Link>
+                                            <div className="mb-1.5">
+                                                <ArtistRatingInline
+                                                    rating={rp.artist.artistRating ?? 0}
+                                                    reviewCount={rp.artist.reviewCount ?? 0}
+                                                    compact
+                                                />
+                                            </div>
+                                            <Link to={`/products/${rp.id}`} className="no-underline block">
+                                                <h3 className="font-display text-[13px] sm:text-[15px] font-bold text-neutral-black mb-2 truncate hover:text-primary transition-colors">
+                                                    {rp.name}
+                                                </h3>
+                                            </Link>
+                                            <div className="flex items-center justify-between mb-3 gap-2 flex-wrap">
+                                                <div className="flex items-baseline gap-2 min-w-0">
+                                                    <span className="font-display text-[14px] sm:text-[16px] font-black text-neutral-black shrink-0">
+                                                        ₹{rp.price.toLocaleString("en-IN")}
+                                                    </span>
+                                                    {rp.isDiscounted && (
+                                                        <span className="font-display text-[10px] sm:text-[11px] font-bold text-neutral-g3 line-through truncate">
+                                                            ₹{rp.originalPrice?.toLocaleString("en-IN")}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <span className="font-display text-[8px] sm:text-[9px] font-bold tracking-[1px] uppercase text-neutral-g3 bg-neutral-g1 px-1.5 py-0.5 shrink-0 max-w-[100px] truncate">
+                                                    {(rp.categories?.[0] || "Design").toString()}
+                                                </span>
+                                            </div>
+                                            <button
+                                                type="button"
+                                                onClick={() => handleRelatedQuickAdd(rp)}
+                                                className={`w-full py-2 sm:py-2.5 font-display text-[10px] sm:text-[11px] font-extrabold tracking-[1px] uppercase rounded-[3px] transition-all border-[1.5px] ${
+                                                    relatedAddedId === rp.id
+                                                        ? "bg-success text-white border-success"
+                                                        : "bg-neutral-black text-white border-neutral-black hover:bg-primary hover:text-neutral-black hover:border-primary"
+                                                }`}
+                                            >
+                                                {relatedAddedId === rp.id ? "Added!" : "+ Add to cart"}
+                                            </button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </section>
+                )}
             </div>
 
             <SizeGuideModal open={sizeGuideOpen} onClose={() => setSizeGuideOpen(false)} />


### PR DESCRIPTION
…codes

- ProductDetails: related products grid (shop-style), remove right column scroll
- Cart: size chips match PDP styling
- Home: flash/category cards show artist link, title underline hover; trust tile 5–7 day note
- Admin orders: designCodesLabeled (front/back), storefront product link in modal
- Backend: design reuse checks include draftEditorState; designs isManifested uses same
- SelectDesignModal: handleSelect aligns with grid manifested rules